### PR TITLE
Increase the size of the stepper tooltips so I can house larger numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.0.1
+## Increase the size of the stepper tooltips
+Increased the max width to 300px from 200px.
+
 # v1.0.0
 ## Allow all steps to be clickable in stepper instead of only the previous ones
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/components",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "TransferWise styleguide components in react",
   "license": "MIT",
   "main": "./build/main.js",

--- a/src/tooltip/Tooltip.less
+++ b/src/tooltip/Tooltip.less
@@ -1,3 +1,7 @@
 .tooltip-container {
   display: inline-block;
 }
+
+.tooltip-inner {
+  max-width: 300px;
+}


### PR DESCRIPTION
<img width="274" alt="screen shot 2017-12-18 at 15 08 08" src="https://user-images.githubusercontent.com/1809691/34112698-4dc79f64-e405-11e7-940b-6e35ec04dcbb.png">

Increased the max-width from 200px to 300px.

Bug was raised under https://transferwise.atlassian.net/browse/CON-966