### PR TITLE
flowNavigation hover label renders jsx not strings->html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# v11.1.1
-## flowNavigation hover label renders jsx not strings->html
-flowNavigation hover label prefers jsx over a string being evaluated to html
+# v12.0.0
+## flowNavigation hover label renders jsx not strings->HTML
+flowNavigation hover label no longer accepts rendering strings->HTML. hoverHTML-flag is removed.
+Any Types.node, e.g. string or element/jsx, are accepted instead.
 
 # v11.1.0
 ## Add disabled property to options in Select component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v11.0.4
+## flowNavigation hover label renders jsx not strings->html
+flowNavigation hover label prefers jsx over a string being evaluated to html
+
 # v11.0.3
 ## Import single function lodash packages instead of whole package
 Importing the whole `lodash` package had a side effect of attaching itself as `_` on global context (`window`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/components",
-  "version": "11.0.3",
+  "version": "11.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/components",
-  "version": "11.1.1",
+  "version": "12.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/components",
-  "version": "11.1.1",
+  "version": "12.0.0",
   "description": "TransferWise styleguide components in react",
   "license": "MIT",
   "main": "./build/main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/components",
-  "version": "11.0.3",
+  "version": "11.0.4",
   "description": "TransferWise styleguide components in react",
   "license": "MIT",
   "main": "./build/main.js",

--- a/src/flowNavigation/FlowNavigation.docs.js
+++ b/src/flowNavigation/FlowNavigation.docs.js
@@ -40,13 +40,25 @@ export default class FlowNavigationDocs extends Component {
         steps: [
           {
             label: 'Amount',
-            hoverLabel: '<strong>100 GBP</strong> <br> 0.2351 ETH',
-            hoverHTML: true,
+            hoverLabel: (
+              <>
+                <div>
+                  <strong>100 GBP</strong>
+                </div>
+                0.2351 ETH
+              </>
+            ),
           },
           {
             label: 'My details',
-            hoverLabel: '<strong>Diana Jaramillo</strong> <br> dianajarm123@gmail.com',
-            hoverHTML: true,
+            hoverLabel: (
+              <>
+                <div>
+                  <strong>Diana Jaramillo</strong>
+                </div>
+                dianajarm123@gmail.com
+              </>
+            ),
           },
           { label: 'Recipient', hoverLabel: 'Some person/dog' },
           { label: 'Something', hoverLabel: 'Cool' },

--- a/src/flowNavigation/FlowNavigation.js
+++ b/src/flowNavigation/FlowNavigation.js
@@ -91,8 +91,7 @@ FlowNavigation.propTypes = {
     Types.shape({
       label: Types.string.isRequired,
       onClick: Types.func,
-      hoverLabel: Types.string,
-      hoverHTML: Types.bool,
+      hoverLabel: Types.oneOfType([Types.element, Types.string]),
     }),
   ).isRequired,
   activeStep: Types.number,

--- a/src/flowNavigation/FlowNavigation.js
+++ b/src/flowNavigation/FlowNavigation.js
@@ -91,7 +91,7 @@ FlowNavigation.propTypes = {
     Types.shape({
       label: Types.string.isRequired,
       onClick: Types.func,
-      hoverLabel: Types.oneOfType([Types.element, Types.string]),
+      hoverLabel: Types.node,
     }),
   ).isRequired,
   activeStep: Types.number,

--- a/src/stepper/Stepper.docs.js
+++ b/src/stepper/Stepper.docs.js
@@ -33,13 +33,25 @@ export default class StepperDocs extends Component {
         steps: [
           {
             label: 'Amount',
-            hoverLabel: '<strong>100 GBP</strong> <br> 0.2351 ETH',
-            hoverHTML: true,
+            hoverLabel: (
+              <>
+                <div>
+                  <strong>100 GBP</strong>
+                </div>
+                0.2351 ETH
+              </>
+            ),
           },
           {
             label: 'My details',
-            hoverLabel: '<strong>Diana Jaramillo</strong> <br> dianajarm123@gmail.com',
-            hoverHTML: true,
+            hoverLabel: (
+              <>
+                <div>
+                  <strong>Diana Jaramillo</strong>
+                </div>
+                dianajarm123@gmail.com
+              </>
+            ),
           },
           { label: 'Recipient', hoverLabel: 'Some person/dog' },
           { label: 'Something', hoverLabel: 'Cool' },

--- a/src/stepper/Stepper.js
+++ b/src/stepper/Stepper.js
@@ -67,7 +67,7 @@ Stepper.propTypes = {
     Types.shape({
       label: Types.string.isRequired,
       onClick: Types.func,
-      hoverLabel: Types.oneOfType([Types.element, Types.string]),
+      hoverLabel: Types.node,
     }),
   ).isRequired,
   activeStep: Types.number,

--- a/src/stepper/Stepper.js
+++ b/src/stepper/Stepper.js
@@ -20,13 +20,6 @@ const Stepper = ({ steps, activeStep }) => {
     const active = index === activeStepIndex;
     const clickable = step.onClick && !active;
 
-    const hoverLabel = step.hoverHTML ? (
-      <span
-        dangerouslySetInnerHTML={{ __html: step.hoverLabel }} // eslint-disable-line react/no-danger
-      />
-    ) : (
-      step.hoverLabel
-    );
     const labelButton = (
       <button
         className="btn-unstyled tw-stepper__step-label"
@@ -48,7 +41,7 @@ const Stepper = ({ steps, activeStep }) => {
         `}
       >
         {step.hoverLabel && !isTouchDevice() ? (
-          <Tooltip position={Tooltip.Position.BOTTOM} label={hoverLabel}>
+          <Tooltip position={Tooltip.Position.BOTTOM} label={step.hoverLabel}>
             {labelButton}
           </Tooltip>
         ) : (
@@ -74,8 +67,7 @@ Stepper.propTypes = {
     Types.shape({
       label: Types.string.isRequired,
       onClick: Types.func,
-      hoverLabel: Types.string,
-      hoverHTML: Types.bool,
+      hoverLabel: Types.oneOfType([Types.element, Types.string]),
     }),
   ).isRequired,
   activeStep: Types.number,

--- a/src/stepper/Stepper.spec.js
+++ b/src/stepper/Stepper.spec.js
@@ -209,23 +209,29 @@ describe('Stepper', () => {
       expect(step(1).text()).toEqual('label 2');
     });
 
-    it('will be rendered as html when hoverHTML is truthy', () => {
+    it('renders jsx', () => {
       component.setProps({
         steps: [
-          { hoverLabel: 'hover <p>label</p>', hoverHTML: true, label: '1' },
-          { hoverLabel: 'hover <p>label</p>', label: '2' },
+          {
+            hoverLabel: (
+              <>
+                hover <p>label</p>
+              </>
+            ),
+            label: '1',
+          },
         ],
       });
+
       expect(
         step(0)
           .children()
           .prop('label'),
-      ).toEqual(<span dangerouslySetInnerHTML={{ __html: 'hover <p>label</p>' }} />); // eslint-disable-line react/no-danger
-      expect(
-        step(1)
-          .children()
-          .prop('label'),
-      ).toEqual('hover <p>label</p>');
+      ).toEqual(
+        <>
+          hover <p>label</p>
+        </>,
+      );
     });
 
     it('will not be rendered if the user is on a touch device', () => {

--- a/src/tooltip/Tooltip.js
+++ b/src/tooltip/Tooltip.js
@@ -108,7 +108,7 @@ Tooltip.Position = Position;
 Tooltip.propTypes = {
   children: Types.oneOfType([Types.element, Types.arrayOf(Types.element), Types.string]).isRequired,
   position: Types.oneOf(Object.keys(Tooltip.Position).map(key => Tooltip.Position[key])),
-  label: Types.oneOfType([Types.element, Types.arrayOf(Types.element), Types.string]).isRequired,
+  label: Types.node.isRequired,
   offset: Types.number,
 };
 


### PR DESCRIPTION
flowNavigation hover label prefers jsx over a string being evaluated to html