### PR TITLE
rework button, update implementations in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v12.8.0
+## Make the button component more flexible
+
 # v12.7.1
 ## Add htmlType attribute to Button for changing the default behavior type
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/components",
-  "version": "12.7.1",
+  "version": "12.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/components",
-  "version": "12.7.1",
+  "version": "12.8.0",
   "description": "TransferWise styleguide components in react",
   "license": "MIT",
   "main": "./build/main.js",

--- a/src/button/Button.docs.js
+++ b/src/button/Button.docs.js
@@ -6,8 +6,8 @@ const KNOBS = {
   knobs: [
     {
       type: 'text',
-      label: 'Label',
-      state: 'label',
+      label: 'Children',
+      state: 'children',
       defaultState: 'Send Money',
     },
     {
@@ -22,16 +22,6 @@ const KNOBS = {
     },
     {
       type: 'select',
-      label: 'State',
-      state: 'state',
-      options: Object.values(Button.State).map(value => ({
-        value,
-        label: value,
-      })),
-      defaultState: { value: Button.State.Default, label: Button.State.Default },
-    },
-    {
-      type: 'select',
       label: 'Type',
       state: 'type',
       options: Object.values(Button.Type).map(value => ({
@@ -39,6 +29,28 @@ const KNOBS = {
         label: value,
       })),
       defaultState: { value: Button.Type.Pay, label: Button.Type.Pay },
+    },
+    {
+      type: 'select',
+      label: 'htmlType',
+      state: 'htmlType',
+      options: ['button', 'submit', 'reset'].map(value => ({
+        value,
+        label: value,
+      })),
+      defaultState: { value: 'button', label: 'button' },
+    },
+    {
+      type: 'checkbox',
+      label: 'Loading',
+      state: 'loading',
+      defaultState: false,
+    },
+    {
+      type: 'checkbox',
+      label: 'Disabled',
+      state: 'disabled',
+      defaultState: false,
     },
     {
       type: 'checkbox',
@@ -56,7 +68,7 @@ export default class ButtonDocs extends Component {
   };
 
   render() {
-    const { label, state, size, type, block } = this.state;
+    const { children, size, type, block, disabled, loading, htmlType } = this.state;
 
     return (
       <div className="container">
@@ -69,14 +81,17 @@ export default class ButtonDocs extends Component {
             </div>
             <div className="col-md-6 m-t-2">
               <Button
-                label={label}
                 size={size.value}
-                state={state.value}
                 type={type.value}
+                disabled={disabled}
+                loading={loading}
                 block={block}
+                htmlType={htmlType.value}
                 /* eslint-disable no-alert */
                 onClick={() => alert('Clicked button')}
-              />
+              >
+                {children}
+              </Button>
               <div className="row m-t-5">{KNOBS.knobs.map(knob => generateInput(knob, this))}</div>
             </div>
           </div>

--- a/src/button/Button.js
+++ b/src/button/Button.js
@@ -17,18 +17,9 @@ const Size = {
   Large: 'lg',
 };
 
-const State = {
-  Default: 'default',
-  Loading: 'loading',
-  Disabled: 'disabled',
-};
-
-const Button = ({ label, state, size, type, block, onClick, htmlType }) => {
-  const isLoading = state === State.Loading;
-  const isDisabled = state === State.Disabled || isLoading;
-
+const Button = ({ block, children, disabled, htmlType, loading, size, type, ...rest }) => {
   const classes = classNames(`btn btn-${size}`, {
-    'btn-loading': isLoading,
+    'btn-loading': loading,
     'btn-primary': type === Type.Primary,
     'btn-success': type === Type.Pay,
     'btn-default': type === Type.Secondary,
@@ -37,32 +28,33 @@ const Button = ({ label, state, size, type, block, onClick, htmlType }) => {
   });
 
   return (
-    <button type={htmlType} className={classes} onClick={onClick} disabled={isDisabled}>
-      {label}
-      {isLoading && <span className={classNames('btn-loader', { 'm-l-2': !block })} />}
+    <button type={htmlType} className={classes} disabled={disabled || loading} {...rest}>
+      {children}
+      {loading && <span className={classNames('btn-loader', { 'm-l-2': !block })} />}
     </button>
   );
 };
 
 Button.Type = Type;
 Button.Size = Size;
-Button.State = State;
 
 Button.propTypes = {
   type: Types.oneOf(Object.values(Type)),
   size: Types.oneOf(Object.values(Size)),
-  state: Types.oneOf(Object.values(State)),
+  disabled: Types.bool,
   block: Types.bool,
+  loading: Types.bool,
   onClick: Types.func.isRequired,
-  label: Types.node.isRequired,
+  children: Types.node.isRequired,
   htmlType: Types.oneOf(['submit', 'reset', 'button']),
 };
 
 Button.defaultProps = {
   size: Button.Size.Medium,
   type: Button.Type.Primary,
-  state: Button.State.Default,
+  disabled: false,
   block: false,
+  loading: false,
   htmlType: 'button',
 };
 

--- a/src/dimmer/Dimmer.docs.js
+++ b/src/dimmer/Dimmer.docs.js
@@ -52,7 +52,7 @@ export default class DimmerDocs extends Component {
                     className={classNames('d-flex', 'justify-content-center', 'align-items-center')}
                     style={{ height: '100%' }}
                   >
-                    <Button onClick={() => this.setState({ open: false })} label="Close" />
+                    <Button onClick={() => this.setState({ open: false })}>Close</Button>
                   </div>
                 </Dimmer>
                 <div className="row">

--- a/src/drawer/Drawer.docs.js
+++ b/src/drawer/Drawer.docs.js
@@ -33,7 +33,9 @@ export default class DrawerDocs extends Component {
                   position="right"
                   onClose={() => this.setState({ open: false })}
                   footerContent={
-                    <Button onClick={() => alert('Action clicked')} label="Action" block />
+                    <Button onClick={() => alert('Action clicked')} block>
+                      Action
+                    </Button>
                   }
                   headerTitle="A title"
                 >

--- a/src/modal/Modal.docs.js
+++ b/src/modal/Modal.docs.js
@@ -104,7 +104,11 @@ export default class ModalDocs extends Component {
             size={size.value}
             title={title}
             className={className}
-            footer={<Button label="Action" block onClick={() => alert('clicked')} />}
+            footer={
+              <Button block onClick={() => alert('clicked')}>
+                Action
+              </Button>
+            }
             closeOnClick
           />
         </section>

--- a/src/snackbar/Snackbar.docs.js
+++ b/src/snackbar/Snackbar.docs.js
@@ -73,8 +73,9 @@ import '@transferwise/neptune-css/dist/css/snackbar.css';
                                 : null,
                             })
                           }
-                          label="Show"
-                        />
+                        >
+                          Show
+                        </Button>
                       )}
                     </SnackbarConsumer>
                   </div>

--- a/src/sticky/Sticky.docs.js
+++ b/src/sticky/Sticky.docs.js
@@ -66,7 +66,9 @@ export default class StickyDocs extends Component {
                   )}
                   style={{ padding: '20px', ...styleContent }}
                 >
-                  <Button label="Give Access" onClick={() => alert('clicked')} block />
+                  <Button onClick={() => alert('clicked')} block>
+                    Give Access
+                  </Button>
                   <a href="/" onClick={() => alert('clicked')} className="m-t-3">
                     Switch account
                   </a>


### PR DESCRIPTION
- Use `children` instead of a custom prop
- Use the built-in `disabled` and add `loading` prop instead of a generic `state` prop
- Spread any other props people might want to use (`aria-*`, `form*` etc)
- Updated other docs that use `<Button />`